### PR TITLE
Add total page number to the footer

### DIFF
--- a/templates/camt053-to-fo.xsl
+++ b/templates/camt053-to-fo.xsl
@@ -47,11 +47,14 @@
                         <xsl:value-of select="$i18n/page"/>
                         <xsl:text> </xsl:text>
                         <fo:page-number/>
+                        <xsl:text> / </xsl:text>
+                        <fo:page-number-citation ref-id="last-page"/>
                     </fo:block>
                 </fo:static-content>
 
                 <fo:flow flow-name="xsl-region-body">
                     <xsl:apply-templates select="//camt:Stmt"/>
+                    <fo:block id="last-page"/>
                 </fo:flow>
             </fo:page-sequence>
         </fo:root>


### PR DESCRIPTION
Implemented total page number citation in the account statement PDF footer. Added an empty block with id="last-page" at the end of the FO flow and used fo:page-number-citation in the xsl-region-after section to display the total count. Verified with multi-page statements and across all supported languages.

Fixes #25

---
*PR created automatically by Jules for task [5741897273488045630](https://jules.google.com/task/5741897273488045630) started by @chatelao*